### PR TITLE
Update process-occupancies.ahk

### DIFF
--- a/process-occupancies.ahk
+++ b/process-occupancies.ahk
@@ -202,7 +202,7 @@ GetShutoffs()
 		UnitCheckout := CSV_ReadCell(2, A_Index, ColUnit)
 		OccupiedFlag := 0
 		
-		OccupiedFlag += UnitSearch(occupied, 3, UnitCheckout)
+		OccupiedFlag += UnitSearch(occupiedlist, 3, UnitCheckout)
 		OccupiedFlag += UnitSearch(checkins, 4, UnitCheckout)
 
 		if OccupiedFlag = 0


### PR DESCRIPTION
Fixed bug in shutoff list processing--CSV column reference placeholder variable was being accessed, instead of occupied list filename.
